### PR TITLE
Fix for frequency hopper interface object

### DIFF
--- a/trx_examples/targeting/frequency-hopping/FrequencyHopper.m
+++ b/trx_examples/targeting/frequency-hopping/FrequencyHopper.m
@@ -19,13 +19,17 @@ classdef FrequencyHopper < adi.common.Attribute & ...
         dataTypeStr = 'int16';
         phyDevName = 'axi-hopper';
         iioDevPHY
-        channelCount = 0;
         devName = 'axi-hopper';
         SamplesPerFrame = 0;
     end
     
+    properties (Hidden, Constant, Logical)
+        ComplexData = false;
+    end
+    
     properties(Nontunable, Hidden, Constant)
         Type = 'Rx';
+        channel_names = {''};
     end
     
     properties (Hidden, Nontunable, Access = protected)
@@ -87,6 +91,32 @@ classdef FrequencyHopper < adi.common.Attribute & ...
     
     %% API Functions
     methods (Hidden, Access = protected)
+        function setupImpl(obj)
+            % Setup LibIIO
+            setupLib(obj);
+            
+            % Initialize the pointers
+            initPointers(obj);
+            
+            getContext(obj);
+            
+            setContextTimeout(obj);
+            
+            % Get the device
+            obj.iioDev = getDev(obj, obj.devName);
+            
+            obj.needsTeardown = true;
+            
+                        
+            % Pre-calculate values to be used faster in stepImpl()
+            obj.pIsInSimulink = coder.const(obj.isInSimulink);
+            obj.pNumBufferBytes = coder.const(obj.numBufferBytes);
+            setupInit(obj);
+        end
+        function [data,valid] = stepImpl(~)
+            data = 0;
+            valid = false;
+        end
         function setupInit(obj)
             % Do writes directly to hardware without using set methods.
             % This is required sine Simulink support doesn't support


### PR DESCRIPTION
This change makes the frequency hopping interface class usable for those who cannot modify the base libiio classes since they are normally pcoded. This was done by overriding core implemented functions.

Signed-off-by: Travis F. Collins <travis.collins@analog.com>