### PR TITLE
LTE_PA: move to switch

### DIFF
--- a/trx_examples/streaming/LTE_PA_App/@LTEAppInternals/PlutoRadio.m
+++ b/trx_examples/streaming/LTE_PA_App/@LTEAppInternals/PlutoRadio.m
@@ -4,20 +4,19 @@ function dataRx = PlutoRadio(obj, app, dataTx, frame_ind)
         switch (app.BWDropDown.Value)
             case '3 MHz'
                 TxFilt = load('lte3_filter_tx.mat');
-                obj.PlutoTx = sdrtx('Pluto', TxFilt.filtnv{:});
             case '5 MHz'
                 TxFilt = load('lte5_filter_tx.mat');
-                obj.PlutoTx = sdrtx('Pluto', TxFilt.filtnv{:});
             case '10 MHz'
                 TxFilt = load('lte10_filter_tx.mat');
-                obj.PlutoTx = sdrtx('Pluto', TxFilt.filtnv{:});
             case '15 MHz'
                 TxFilt = load('lte15_filter_tx.mat');
-                obj.PlutoTx = sdrtx('Pluto', TxFilt.filtnv{:});
             case '20 MHz'
                 TxFilt = load('lte20_filter_tx.mat');
-                obj.PlutoTx = sdrtx('Pluto', TxFilt.filtnv{:});
+            otherwise
+                st = dbstack;
+                error("unknown option %s in %s", app.BWDropDown.Value, st.name);
         end
+        obj.PlutoTx = sdrtx('Pluto', TxFilt.filtnv{:});
 
         % tx setup
         obj.PlutoTx.UseCustomFilter = true;
@@ -33,20 +32,20 @@ function dataRx = PlutoRadio(obj, app, dataTx, frame_ind)
     switch (app.BWDropDown.Value)
         case '3 MHz'
             RxFilt = load('lte3_filter_rx.mat');
-            obj.PlutoRx = sdrrx('Pluto', RxFilt.filtnv{:}); 
         case '5 MHz'
-            RxFilt = load('lte5_filter_rx.mat');
-            obj.PlutoRx = sdrrx('Pluto', RxFilt.filtnv{:}); 
+            RxFilt = load('lte5_filter_rx.mat'); 
         case '10 MHz'
             RxFilt = load('lte10_filter_rx.mat');
-            obj.PlutoRx = sdrrx('Pluto', RxFilt.filtnv{:}); 
         case '15 MHz'
             RxFilt = load('lte15_filter_rx.mat');
-            obj.PlutoRx = sdrrx('Pluto', RxFilt.filtnv{:}); 
         case '20 MHz'
             RxFilt = load('lte20_filter_rx.mat');
-            obj.PlutoRx = sdrrx('Pluto', RxFilt.filtnv{:}); 
+        otherwise
+            st = dbstack;
+            error("unknown option %s in %s", app.BWDropDown.Value, st.name);
     end
+    obj.PlutoRx = sdrrx('Pluto', RxFilt.filtnv{:});
+    
     % rx setup
     obj.PlutoRx.UseCustomFilter = true;
     obj.PlutoRx.CenterFrequency = app.LOEditField.Value*1e6;
@@ -76,6 +75,9 @@ function dataRx = PlutoRadio(obj, app, dataTx, frame_ind)
                 obj.PlutoRx.SamplesPerFrame = 2^21;
             case '20 MHz'
                 obj.PlutoRx.SamplesPerFrame = 2^21;
+            otherwise
+                st = dbstack;
+                error("unknown option %s in %s", app.BWDropDown.Value, st.name);
         end
     end
     

--- a/trx_examples/streaming/LTE_PA_App/LTEApp.m
+++ b/trx_examples/streaming/LTE_PA_App/LTEApp.m
@@ -1331,34 +1331,27 @@ classdef LTEApp < matlab.apps.AppBase
                 cla(app.evmRBAxes); drawnow; 
                 cla(app.evmSCAxes); drawnow; 
                 cla(app.evmSymsAxes); drawnow; 
-                cla(app.constAxes); drawnow;                
-                                
-                if strcmp(app.BWDropDown.Value, '3 MHz')
-                    app.evmSCAxes.XLim = [1 15*12];
-                    app.evmRBAxes.XLim = [1 15];
-                    app.numSCs = 15*12;
-                    app.RBs = 15;
-                elseif strcmp(app.BWDropDown.Value, '5 MHz')
-                    app.evmSCAxes.XLim = [1 25*12];
-                    app.evmRBAxes.XLim = [1 25];
-                    app.numSCs = 25*12;
-                    app.RBs = 25;
-                elseif strcmp(app.BWDropDown.Value, '10 MHz')
-                    app.evmSCAxes.XLim = [1 50*12];
-                    app.evmRBAxes.XLim = [1 50];
-                    app.numSCs = 50*12;
-                    app.RBs = 50;
-                elseif strcmp(app.BWDropDown.Value, '15 MHz')
-                    app.evmSCAxes.XLim = [1 75*12];
-                    app.evmRBAxes.XLim = [1 75];
-                    app.numSCs = 75*12;
-                    app.RBs = 75;                    
-                elseif strcmp(app.BWDropDown.Value, '20 MHz')
-                    app.evmSCAxes.XLim = [1 100*12];
-                    app.evmRBAxes.XLim = [1 100];
-                    app.numSCs = 100*12;
-                    app.RBs = 100;                    
+                cla(app.constAxes); drawnow;
+ 
+                switch (app.BWDropDown.Value)             
+                    case '3 MHz'
+                        app.RBs = 15;
+                    case '5 MHz'
+                        app.RBs = 25;
+                    case '10 MHz'
+                        app.RBs = 50;
+                    case '15 MHz'
+                        app.RBs = 75;                    
+                    case '20 MHz'
+                        app.RBs = 100;
+                    otherwise
+                        st = dbstack;
+                        error("unknown option %s in %s", app.BWDropDown.Value, st.name);
                 end
+                app.numSCs = app.RBs*12;
+                app.evmSCAxes.XLim = [1 app.numSCs];
+                app.evmRBAxes.XLim = [1 app.RBs];
+                
                 
                 app.PBCHCheckBox.Enable = 'off';
                 app.PCFICHCheckBox.Enable = 'off';
@@ -1429,33 +1422,25 @@ classdef LTEApp < matlab.apps.AppBase
             cla(app.evmSymsAxes); drawnow; 
             cla(app.constAxes); drawnow;                
             
-            if strcmp(app.BWDropDown.Value, '3 MHz')
-                app.evmSCAxes.XLim = [1 15*12];
-                app.evmRBAxes.XLim = [1 15];
-                app.numSCs = 15*12;
-                app.RBs = 15;
-            elseif strcmp(app.BWDropDown.Value, '5 MHz')
-                app.evmSCAxes.XLim = [1 25*12];
-                app.evmRBAxes.XLim = [1 25];
-                app.numSCs = 25*12;
-                app.RBs = 25;
-            elseif strcmp(app.BWDropDown.Value, '10 MHz')
-                app.evmSCAxes.XLim = [1 50*12];
-                app.evmRBAxes.XLim = [1 50];
-                app.numSCs = 50*12;
-                app.RBs = 50;
-            elseif strcmp(app.BWDropDown.Value, '15 MHz')
-                app.evmSCAxes.XLim = [1 75*12];
-                app.evmRBAxes.XLim = [1 75];
-                app.numSCs = 75*12;
-                app.RBs = 75;
-            elseif strcmp(app.BWDropDown.Value, '20 MHz')
-                app.evmSCAxes.XLim = [1 100*12];
-                app.evmRBAxes.XLim = [1 100];
-                app.numSCs = 100*12;
-                app.RBs = 100;
-            end
-
+            switch (app.BWDropDown.Value)             
+                case '3 MHz'
+                    app.RBs = 15;
+                case '5 MHz'
+                    app.RBs = 25;
+                case '10 MHz'
+                    app.RBs = 50;
+                case '15 MHz'
+                    app.RBs = 75;                    
+                case '20 MHz'
+                    app.RBs = 100;
+                otherwise
+                    st = dbstack;
+                    error("unknown option %s in %s", app.BWDropDown.Value, st.name);
+             end
+            app.numSCs = app.RBs*12;
+            app.evmSCAxes.XLim = [1 app.numSCs];
+            app.evmRBAxes.XLim = [1 app.RBs];
+                
             app.PBCHCheckBox.Enable = 'off';
             app.PCFICHCheckBox.Enable = 'off';
             app.PHICHCheckBox.Enable = 'off';


### PR DESCRIPTION
Move to switch from if thenelse (it's shorter, and easier to read), add an otherwise (for catching errors), and move common things outside the loop

Signed-off-by: Robin Getz <robin.getz@analog.com>