### PR TITLE
Make UID parameterizable for BSP templates

### DIFF
--- a/CI/scripts/bsp.tmpl
+++ b/CI/scripts/bsp.tmpl
@@ -39,7 +39,7 @@ Support: https://ez.analog.com/</param.description>
       <item>9.0</item>
     </param.products.version>
     <param.platforms />
-    <param.guid>40075943-d2d1-4d90-8e59-b3eff5f58180</param.guid>
+    <param.guid>__UUID__</param.guid>
     <param.exclude.filters>%
 CI/*
 hdl_prj/*

--- a/CI/scripts/bsp_noexamples.tmpl
+++ b/CI/scripts/bsp_noexamples.tmpl
@@ -39,7 +39,7 @@ Support: https://ez.analog.com/</param.description>
       <item>9.0</item>
     </param.products.version>
     <param.platforms />
-    <param.guid>40075943-d2d1-4d90-8e59-b3eff5f58180</param.guid>
+    <param.guid>__UUID__</param.guid>
     <param.exclude.filters>%
 CI/*
 deps/*

--- a/CI/scripts/genTlbx.m
+++ b/CI/scripts/genTlbx.m
@@ -7,6 +7,7 @@ end
 version = '20.1.2';
 ml = ver('MATLAB');
 ml = ml.Release(2:end-1);
+uuid = matlab.lang.internal.uuid;
 
 %% Unpack verilog source
 if ~examples
@@ -35,6 +36,7 @@ fclose(fid);
 f = strrep(f,'__REPO-ROOT__',p);
 f = strrep(f,'__VERSION__',version);
 f = strrep(f,'__ML-RELEASE__',ml);
+f = strrep(f,'__UUID__',uuid);
 
 fid  = fopen('../../bsp.prj','w');
 fprintf(fid,'%s',f);


### PR DESCRIPTION
This change will make UIDs unique on every release. Preventing collisions with other toolboxes.

Signed-off-by: Travis F. Collins <travis.collins@analog.com>