### PR TITLE
AD9361 Attribute read/write tests (#72)

### DIFF
--- a/+adi/+AD9361/Rx.m
+++ b/+adi/+AD9361/Rx.m
@@ -35,7 +35,7 @@ classdef Rx < adi.AD9361.Base & adi.AD9361.TuneAGC & ...
         %   'hybrid' — For configuring hybrid AGC mode
         GainControlModeChannel0 = 'slow_attack';
         %GainChannel0 Gain Channel 0
-        %   Channel 0 gain, specified as a scalar from -4 dB to 71 dB. The acceptable
+        %   Channel 0 gain, specified as a scalar from -3 dB to 71 dB. The acceptable
         %   minimum and maximum gain setting depends on the center
         %   frequency.
         GainChannel0 = 10;
@@ -47,7 +47,7 @@ classdef Rx < adi.AD9361.Base & adi.AD9361.TuneAGC & ...
         %   'hybrid' — For configuring hybrid AGC mode
         GainControlModeChannel1 = 'slow_attack';
         %GainChannel1 Gain Channel 1
-        %   Channel 1 gain, specified as a scalar from -4 dB to 71 dB. The acceptable
+        %   Channel 1 gain, specified as a scalar from -3 dB to 71 dB. The acceptable
         %   minimum and maximum gain setting depends on the center
         %   frequency.
         GainChannel1 = 10;
@@ -157,25 +157,25 @@ classdef Rx < adi.AD9361.Base & adi.AD9361.TuneAGC & ...
         % Check GainChannel0
         function set.GainChannel0(obj, value)
             validateattributes( value, { 'double','single' }, ...
-                { 'real', 'scalar', 'finite', 'nonnan', 'nonempty', '>=', -4,'<=', 71}, ...
+                { 'real', 'scalar', 'finite', 'nonnan', 'nonempty', '>=', -3,'<=', 71}, ...
                 '', 'Gain');
-            assert(mod(value,1/4)==0, 'Gain must be a multiple of 0.25');
+            assert(mod(value,1)==0, 'Gain must be an integer');
             obj.GainChannel0 = value;
             if obj.ConnectedToDevice && strcmp(obj.GainControlModeChannel0,'manual') %#ok<MCSUP>
                 id = 'voltage0';
-                obj.setAttributeLongLong(id,'hardwaregain',value,false);
+                obj.setAttributeDouble(id,'hardwaregain',value,false);
             end
         end
         % Check GainChannel1
         function set.GainChannel1(obj, value)
             validateattributes( value, { 'double','single' }, ...
-                { 'real', 'scalar', 'finite', 'nonnan', 'nonempty', '>=', -4,'<=', 71}, ...
+                { 'real', 'scalar', 'finite', 'nonnan', 'nonempty', '>=', -3,'<=', 71}, ...
                 '', 'Gain');
-            assert(mod(value,1/4)==0, 'Gain must be a multiple of 0.25');
+            assert(mod(value,1)==0, 'Gain must be an integer');
             obj.GainChannel1 = value;
             if obj.ConnectedToDevice && strcmp(obj.GainControlModeChannel1,'manual') %#ok<MCSUP>
                 id = 'voltage1';
-                obj.setAttributeLongLong(id,'hardwaregain',value,false);
+                obj.setAttributeDouble(id,'hardwaregain',value,false);
             end
         end
         % Check EnableQuadratureTracking
@@ -286,10 +286,10 @@ classdef Rx < adi.AD9361.Base & adi.AD9361.TuneAGC & ...
                 obj.setAttributeRAW('voltage1','gain_control_mode',obj.GainControlModeChannel1,false);
             end
             if strcmp(obj.GainControlModeChannel0,'manual')
-                obj.setAttributeLongLong('voltage0','hardwaregain',obj.GainChannel0,false);
+                obj.setAttributeDouble('voltage0','hardwaregain',obj.GainChannel0,false);
             end
             if strcmp(obj.GainControlModeChannel1,'manual') && (obj.channelCount>2)
-                obj.setAttributeLongLong('voltage1','hardwaregain',obj.GainChannel1,false);
+                obj.setAttributeDouble('voltage1','hardwaregain',obj.GainChannel1,false);
             end
             % Trackings
             obj.setAttributeBool('voltage0','quadrature_tracking_en',obj.EnableQuadratureTracking,false);

--- a/+adi/+AD9361/Tx.m
+++ b/+adi/+AD9361/Tx.m
@@ -85,7 +85,7 @@ classdef Tx < adi.AD9361.Base & adi.common.Tx
             obj.AttenuationChannel0 = value;
             if obj.ConnectedToDevice
                 id = 'voltage0';
-                obj.setAttributeLongLong(id,'hardwaregain',value,true);
+                obj.setAttributeDouble(id,'hardwaregain',value,true);
             end
         end
         % Check Attentuation
@@ -97,7 +97,7 @@ classdef Tx < adi.AD9361.Base & adi.common.Tx
             obj.AttenuationChannel1 = value;
             if obj.ConnectedToDevice
                 id = 'voltage1';
-                obj.setAttributeLongLong(id,'hardwaregain',value,true);
+                obj.setAttributeDouble(id,'hardwaregain',value,true);
             end
         end
         % Check CenterFrequency
@@ -108,7 +108,7 @@ classdef Tx < adi.AD9361.Base & adi.common.Tx
                     '', 'CenterFrequency');
             else
                 validateattributes( value, { 'double','single' }, ...
-                    { 'real', 'positive','scalar', 'finite', 'nonnan', 'nonempty','integer','>=',70e6,'<=',6e9}, ...
+                    { 'real', 'positive','scalar', 'finite', 'nonnan', 'nonempty','integer','>=',47e6,'<=',6e9}, ...
                     '', 'CenterFrequency');
             end
             obj.CenterFrequency = value;
@@ -125,7 +125,7 @@ classdef Tx < adi.AD9361.Base & adi.common.Tx
                     '', 'RFBandwidth');
             else
                 validateattributes( value, { 'double','single' }, ...
-                    { 'real', 'positive','scalar', 'finite', 'nonnan', 'nonempty','integer','>=',200e3,'<=',40e6}, ...
+                    { 'real', 'positive','scalar', 'finite', 'nonnan', 'nonempty','integer','>=',200e3,'<=',56e6}, ...
                     '', 'RFBandwidth');
                 
             end
@@ -182,9 +182,9 @@ classdef Tx < adi.AD9361.Base & adi.common.Tx
                 writeFilterFile(obj);
             end
             
-            obj.setAttributeLongLong('voltage0','hardwaregain',obj.AttenuationChannel0,true);
+            obj.setAttributeDouble('voltage0','hardwaregain',obj.AttenuationChannel0,true);
             if obj.channelCount>2
-                obj.setAttributeLongLong('voltage1','hardwaregain',obj.AttenuationChannel1,true);
+                obj.setAttributeDouble('voltage1','hardwaregain',obj.AttenuationChannel1,true);
             end
             obj.ToggleDDS(strcmp(obj.DataSource,'DDS'));
             if strcmp(obj.DataSource,'DDS')

--- a/test/AD9361Tests.m
+++ b/test/AD9361Tests.m
@@ -4,6 +4,33 @@ classdef AD9361Tests < HardwareTests
         uri = 'ip:analog';
         author = 'ADI';
     end
+
+    properties (TestParameter)
+        attribute_single_value = {
+                % object, property, valtype, id, isOutput, attribute, start, stop, step, tol, repeats
+                {'rx', 'SamplingRate', 'LongLong', 'voltage1', false, 'sampling_frequency', 2.084e6, 61.44e6, 10e3, 4, 20};
+                {'rx', 'CenterFrequency', 'LongLong', 'altvoltage0', true, 'frequency', 70e6, 6e9, 1e6, 4, 100};
+                {'rx', 'RFBandwidth', 'LongLong', 'voltage0', false, 'rf_bandwidth', 200e3, 56e6, 10e3, 30, 20};
+                {'rx', 'GainChannel0', 'Double', 'voltage0', false, 'hardwaregain', -3, 71, 1, 0, 20};
+                {'rx', 'GainChannel1', 'Double', 'voltage1', false, 'hardwaregain', -3, 71, 1, 0, 20};
+                {'tx', 'CenterFrequency', 'LongLong', 'altvoltage1', true, 'frequency', 47e6, 6e9, 1e6, 4, 100};
+                {'tx', 'RFBandwidth', 'LongLong', 'voltage1', true, 'rf_bandwidth',  200e3, 56e6, 10e3, 30, 20};
+                {'tx', 'AttenuationChannel0', 'Double', 'voltage0', true, 'hardwaregain', -89.75, 0.0, 0.25, 0, 20};
+                {'tx', 'AttenuationChannel1', 'Double', 'voltage1', true, 'hardwaregain', -89.75, 0.0, 0.25, 0, 20};
+            }
+        attribute_single_value_str = {
+                % attr, option
+                {'rx', 'GainControlModeChannel0', 'RAW', 'voltage0', false, 'gain_control_mode',["manual","slow_attack","fast_attack","hybrid"]};
+                {'rx', 'GainControlModeChannel1', 'RAW', 'voltage1', false, 'gain_control_mode',["manual","slow_attack","fast_attack","hybrid"]};
+                {'rx', 'RFPortSelect', 'RAW', 'voltage1', false,'rf_port_select',["A_BALANCED","B_BALANCED","C_BALANCED","A_N","A_P","B_N","B_P",...
+                            "C_N","C_P","TX_MONITOR1","TX_MONITOR2","TX_MONITOR1_2"]};
+                {'rx', 'LoopbackMode', 'DebugLongLong', 'voltage1', false, 'loopback',[0, 1, 2]};
+                {'rx', 'EnableQuadratureTracking', 'Bool', 'voltage1', false, 'quadrature_tracking_en', logical([0 1])};
+                {'rx', 'EnableRFDCTracking', 'Bool', 'voltage1', false, 'rf_dc_offset_tracking_en', logical([0 1])};
+                {'rx', 'EnableBasebandDCTracking', 'Bool', 'voltage1', false, 'bb_dc_offset_tracking_en', logical([0 1])};
+                {'tx', 'RFPortSelect', 'RAW', 'voltage1', true, 'rf_port_select',["A", "B"]};
+            }
+    end
     
     methods(TestClassSetup)
         % Check hardware connected
@@ -22,6 +49,98 @@ classdef AD9361Tests < HardwareTests
         end
     end
     
+    methods (Test)
+    
+        function testAD9361AttributeSingleValue(testCase,attribute_single_value)
+            warning('off') % Mute: "The AttenuationChannel1 property is not relevant in this configuration of the System object."
+            object = (attribute_single_value{1});
+            property = (attribute_single_value{2});
+            valueType = (attribute_single_value{3});
+            id = (attribute_single_value{4});
+            isOutput = (attribute_single_value{5});
+            attr = (attribute_single_value{6});
+            start = (attribute_single_value{7});
+            stop = (attribute_single_value{8});
+            step = (attribute_single_value{9});
+            tol = (attribute_single_value{10});
+            repeats = (attribute_single_value{11});
+            
+            switch object
+            case 'rx'
+                obj = adi.AD9361.Rx('uri',testCase.uri);
+                if strcmp(property(1:end-1),'GainChannel')
+                    obj.EnabledChannels = [1 2];
+                    obj.(strcat('GainControlModeChannel',property(end))) = 'manual';
+                end
+            case 'tx'
+                obj = adi.AD9361.Tx('uri',testCase.uri);
+                obj.DataSource = 'DDS';
+            end
+            obj(); %FIXME: RFBandwidth read errors without stepping before writing
+            
+            numints = round((stop-start)/step);
+            for ii = 1:repeats
+                ind = randi([0, numints]);
+                write_val = start+(step*ind);
+                obj.(property) = write_val;
+                obj();
+                switch valueType
+                    case 'LongLong'
+                        ret_val = double(obj.getAttributeLongLong(id,attr,isOutput));
+                    case 'Double'
+                        ret_val = double(obj.getAttributeDouble(id,attr,isOutput));
+                end
+                testCase.verifyEqual(ret_val,write_val,'AbsTol',tol,...
+                    sprintf('%s.%s: Actual value written to device outside tolerance.', (object), (property)))
+            end
+            obj.release();
+
+        end
+
+        function testAD9361AttributeSingleValueStr(testCase,attribute_single_value_str)
+            object = (attribute_single_value_str{1});
+            property = (attribute_single_value_str{2});
+            valueType = (attribute_single_value_str{3});
+            id = (attribute_single_value_str{4});
+            isOutput = (attribute_single_value_str{5});
+            attr = (attribute_single_value_str{6});
+            option = (attribute_single_value_str{7});
+
+            switch object
+            case 'rx'
+                obj = adi.AD9361.Rx('uri',testCase.uri);
+                obj.EnabledChannels = [1 2];
+            case 'tx'
+                obj = adi.AD9361.Tx('uri',testCase.uri);
+                obj.DataSource = 'DDS';
+            end
+
+            if strcmp(property(1:end-1),'GainControlModeChannel')
+                obj();
+            end
+
+            for ii = 1:length(option)
+                obj.(property) = option(ii);
+                obj();
+                switch valueType
+                case 'DebugLongLong'
+                    ret_val = obj.getDebugAttributeLongLong(attr);
+                case 'Bool'
+                    ret_val = obj.getAttributeBool(id,attr,isOutput);
+                case 'RAW'
+                    ret_val = obj.getAttributeRAW(id,attr,isOutput);
+                end
+                if ~strcmp(property(1:end-1),'GainControlModeChannel')
+                    obj.release(); %FIXME: Releasing here will not work for GainControlMode
+                end
+                testCase.verifyTrue(strcmp(string(ret_val),string(option(ii))),...
+                    sprintf('%s.%s: Cannot set channel attribute to %s.', (object), (property), string(option(ii))))
+            end
+            obj.release();
+        end
+        
+    end
+
     methods (Test)
         
         function testAD9361Rx(testCase)


### PR DESCRIPTION
Cherrypick from R2020a branch which got the new tests.

* Attribute read/write test
* set.GainChannel0/1 using setAttributeDouble instead of LongLong
* Changed RF Bandwidth upper limit to 56MHz, Center Frequency lower limit to 47MHz, set.AttenuationChannel0/1 using setAttributeDouble instead of LongLong
* Changed hardwaregain setAttribute to Double instead of LongLong
* Add rx manual gain check in AttributeSingleValue
* Change GainChannel step from 0.25 to 1
* Set EnabledChannels property to [1 2] instead of 2 for rx.