### PR TITLE
Fix telemetry call

### DIFF
--- a/test/LTE_Tests/runLTETests.m
+++ b/test/LTE_Tests/runLTETests.m
@@ -54,7 +54,7 @@ function results = runLTETests(BoardName, LOStepSize, server)
         if nargin == 3
             telemetry.ingest.log_lte_test(results,datestr(now,'yyyy-mm-ddTHH:MM:SS.FFF'),server,0);
         else
-            telemetry.ingest.log_lte_test(results,datestr(now,'yyyy-mm-ddTHH:MM:SS.FFF'));
+            telemetry.ingest.log_lte_test(results);
         end
     catch
         warning('telemetry not found');

--- a/test/LTE_Tests/runLTETests.m
+++ b/test/LTE_Tests/runLTETests.m
@@ -1,4 +1,4 @@
-function results = runLTETests(BoardName, LOStepSize)
+function results = runLTETests(BoardName, LOStepSize, server)
     import matlab.unittest.parameters.Parameter
     import matlab.unittest.TestSuite
     import matlab.unittest.TestRunner
@@ -51,7 +51,11 @@ function results = runLTETests(BoardName, LOStepSize)
     runner.addPlugin(plugin);
     results = runner.run(suite);
     try
-        telemetry.ingest.log_lte_test(results,datestr(now,'yyyy-mm-ddTHH:MM:SS.FFF'),getenv('server'));
+        if nargin == 3
+            telemetry.ingest.log_lte_test(results,datestr(now,'yyyy-mm-ddTHH:MM:SS.FFF'),server,0);
+        else
+            telemetry.ingest.log_lte_test(results,datestr(now,'yyyy-mm-ddTHH:MM:SS.FFF'));
+        end
     catch
         warning('telemetry not found');
     end

--- a/test/LTE_Tests/runLTETests.m
+++ b/test/LTE_Tests/runLTETests.m
@@ -51,7 +51,7 @@ function results = runLTETests(BoardName, LOStepSize)
     runner.addPlugin(plugin);
     results = runner.run(suite);
     try
-        log_lte_evm_test(results);
+        telemetry.ingest.log_lte_test(results,datestr(now,'yyyy-mm-ddTHH:MM:SS.FFF'),getenv('server'));
     catch
         warning('telemetry not found');
     end


### PR DESCRIPTION
- Fixed telemetry function call
- Added server input argument in runLTETests to pass server address for telemetry call but passing results only is still supported