### PR TITLE
HW test updates

### DIFF
--- a/JenkinsfileHW
+++ b/JenkinsfileHW
@@ -4,19 +4,22 @@ lock(label: 'adgt_test_harness_boards') {
     def hdlBranch = "NA"
     def linuxBranch = "NA"
     def bootPartitionBranch = "release"
-    def firmwareVersion = 'v0.32'
+    def firmwareVersion = 'v0.34'
     def bootfile_source = 'artifactory' // options: sftp, artifactory, http, local
     def harness = getGauntlet(hdlBranch, linuxBranch, bootPartitionBranch, firmwareVersion, bootfile_source)
   
     //Udpate repos
     harness.set_env('nebula_repo', 'https://github.com/sdgtt/nebula.git')
-    harness.set_env('nebula_branch','dev_fixes')
-    harness.set_env('libiio_branch', 'v0.21')
+    harness.set_env('nebula_branch','dev')
+    harness.set_env('nebula_config_branch','release')
+    harness.set_env('libiio_branch', 'v0.23')
     harness.set_env('telemetry_repo', 'https://github.com/sdgtt/telemetry.git')
     harness.set_env('telemetry_branch', 'master')
+    harness.set_env('matlab_repo', 'https://github.com/analogdevicesinc/TransceiverToolbox.git') // Not necessary when using checkout scm
     harness.set_env('matlab_release','R2021a')
   
     //Update agent with required deps
+    harness.set_required_agent(["sdg-nuc-01","sdg-nuc-02"])
     harness.update_agents()
   
     //Set other test parameters
@@ -24,6 +27,7 @@ lock(label: 'adgt_test_harness_boards') {
     harness.set_enable_docker(true)
     harness.set_docker_host_mode(false)
     harness.set_send_telemetry(false)
+    harness.set_log_jira(true)
     harness.set_enable_resource_queuing(true)
     harness.set_lock_agent(true) // Required for MATLAB toolbox tests
     harness.set_elastic_server('192.168.10.1')
@@ -35,13 +39,13 @@ lock(label: 'adgt_test_harness_boards') {
                                   "zynq-zed-adv7511-ad9361-fmcomms2-3",
                                   "zynq-zc706-adv7511-ad9361-fmcomms5",
                                   "zynq-zc702-adv7511-ad9361-fmcomms2-3",
-                                  "zynq-adrv9364-z7020-bob-cmos"])
+                                  "zynq-adrv9364-z7020-bob-vcmos"])
     harness.set_docker_args(['Vivado', 'MATLAB'])
     harness.set_nebula_local_fs_source_root("artifactory.analog.com")
   
     // Set stages (Stages are run sequentially on agents.)
-    // harness.add_stage(harness.stage_library("UpdateBOOTFiles"), 'stopWhenFail',
-    //                   harness.stage_library("RecoverBoard"))
+    harness.add_stage(harness.stage_library("UpdateBOOTFiles"), 'stopWhenFail',
+                      harness.stage_library("RecoverBoard"))
   
     // Test stage
     harness.set_matlab_commands(["ad=adi.utils.libad9361",

--- a/test/FMComms5Tests.m
+++ b/test/FMComms5Tests.m
@@ -41,14 +41,12 @@ classdef FMComms5Tests < HardwareTests
             testCase.verifyTrue(valid);
             testCase.verifyGreaterThan(sum(abs(double(out))),0);
             for ii = 1:numel(AllEnChsCombos)
-                testCase.verifyNotEqual(testCase, ...
-                    diff(abs(double(out(:,ii)))), ...
+                testCase.verifyNotEqual(diff(abs(double(out(:,ii)))), ...
                     zeros(numel(out(:,ii))-1, 1));
             end
             if (numel(AllEnChsCombos) > 1)
                 for ii = 2:numel(AllEnChsCombos)
-                    testCase.verifyNotEqual(testCase, ...
-                        sum(abs(double(out(:,1)))), ...
+                    testCase.verifyNotEqual(sum(abs(double(out(:,1)))), ...
                         sum(abs(double(out(:,ii)))));                    
                 end
             end
@@ -71,7 +69,7 @@ classdef FMComms5Tests < HardwareTests
             testCase.verifyTrue(valid);
             testCase.verifyEqual(double(sr),3000000,'Incorrect sample rate');
             testCase.verifyGreaterThan(sum(abs(double(out))),0);
-            testCase.verifyNotEqual(testCase, diff(abs(double(out))), ...
+            testCase.verifyNotEqual(diff(abs(double(out))), ...
                 zeros(numel(out)-1, 1));
         end
         
@@ -141,7 +139,7 @@ classdef FMComms5Tests < HardwareTests
             testCase.verifyTrue(valid);
             testCase.verifyEqual(double(sr),23040000,'Incorrect sample rate');
             testCase.verifyGreaterThan(sum(abs(double(out))),0);
-            testCase.verifyNotEqual(testCase, diff(abs(double(out))), ...
+            testCase.verifyNotEqual(diff(abs(double(out))), ...
                 zeros(numel(out)-1, 1));
         end
         


### PR DESCRIPTION
Some hardware tests were failing because of

- incorrect attribute assignment in set methods with optional arguments added/ommitted - this is already fixed in ToolboxCommon, just moving the head in trx toolbox
- inclusion of testCase argument in a verify method that raises invalid type error

The UpdateBOOTFiles stage is called to load the latest Kuiper release and setup board variants required. This stage fails for Pluto. Still working on a fix, or somehow skip the stage for Pluto.

Some zynq-adrv9361-z7035-fmc tests fail with the release image but not on recent master boot files.