### PR TITLE
adrv9001: Fix valid error

### DIFF
--- a/CI/scripts/matlab_processors.tcl
+++ b/CI/scripts/matlab_processors.tcl
@@ -49,25 +49,25 @@ proc preprocess_bd {project carrier rxtx} {
                     connect_bd_net -net [get_bd_nets util_ad9361_divclk_clk_out] [get_bd_pins axi_cpu_interconnect/M07_ACLK] [get_bd_pins util_ad9361_divclk/clk_out]
                     connect_bd_net [get_bd_pins util_ad9361_divclk_reset/interconnect_aresetn] [get_bd_pins axi_cpu_interconnect/M07_ARESETN]
                 }
-                ccbob_lvds {                    
+                ccbob_lvds {
                     # Add 1 extra AXI master ports to the interconnect
                     set_property -dict [list CONFIG.NUM_MI {8}] [get_bd_cells axi_cpu_interconnect]
                     connect_bd_net -net [get_bd_nets util_ad9361_divclk_clk_out] [get_bd_pins axi_cpu_interconnect/M07_ACLK] [get_bd_pins util_ad9361_divclk/clk_out]
                     connect_bd_net [get_bd_pins util_ad9361_divclk_reset/interconnect_aresetn] [get_bd_pins axi_cpu_interconnect/M07_ARESETN]
                 }
-                ccbox_lvds {                    
+                ccbox_lvds {
                     # Add 1 extra AXI master ports to the interconnect
                     set_property -dict [list CONFIG.NUM_MI {6}] [get_bd_cells axi_cpu_interconnect]
                     connect_bd_net -net [get_bd_nets util_ad9361_divclk_clk_out] [get_bd_pins axi_cpu_interconnect/M05_ACLK] [get_bd_pins util_ad9361_divclk/clk_out]
                     connect_bd_net [get_bd_pins util_ad9361_divclk_reset/interconnect_aresetn] [get_bd_pins axi_cpu_interconnect/M05_ARESETN]
-                }                
-                ccfmc_lvds {                    
+                }
+                ccfmc_lvds {
                     # Add 1 extra AXI master ports to the interconnect
                     set_property -dict [list CONFIG.NUM_MI {13}] [get_bd_cells axi_cpu_interconnect]
                     connect_bd_net -net [get_bd_nets util_ad9361_divclk_clk_out] [get_bd_pins axi_cpu_interconnect/M12_ACLK] [get_bd_pins util_ad9361_divclk/clk_out]
                     connect_bd_net [get_bd_pins util_ad9361_divclk_reset/interconnect_aresetn] [get_bd_pins axi_cpu_interconnect/M12_ARESETN]
                 }
-                ccpackrf_lvds {                    
+                ccpackrf_lvds {
                     # Add 1 extra AXI master ports to the interconnect
                     set_property -dict [list CONFIG.NUM_MI {7}] [get_bd_cells axi_cpu_interconnect]
                     connect_bd_net -net [get_bd_nets util_ad9361_divclk_clk_out] [get_bd_pins axi_cpu_interconnect/M06_ACLK] [get_bd_pins util_ad9361_divclk/clk_out]
@@ -144,19 +144,19 @@ proc preprocess_bd {project carrier rxtx} {
                 delete_bd_objs [get_bd_nets util_ad9361_dac_upack_fifo_rd_data_3]
             }
             switch $carrier {
-                zed {                    
+                zed {
                     # Add 1 extra AXI master ports to the interconnect
                     set_property -dict [list CONFIG.NUM_MI {12}] [get_bd_cells axi_cpu_interconnect]
                     connect_bd_net -net [get_bd_nets util_ad9361_divclk_clk_out] [get_bd_pins axi_cpu_interconnect/M11_ACLK] [get_bd_pins util_ad9361_divclk/clk_out]
                     connect_bd_net [get_bd_pins util_ad9361_divclk_reset/interconnect_aresetn] [get_bd_pins axi_cpu_interconnect/M11_ARESETN]
                 }
-                zc702 {                    
+                zc702 {
                     # Add 1 extra AXI master ports to the interconnect
                     set_property -dict [list CONFIG.NUM_MI {10}] [get_bd_cells axi_cpu_interconnect]
                     connect_bd_net -net [get_bd_nets util_ad9361_divclk_clk_out] [get_bd_pins axi_cpu_interconnect/M09_ACLK] [get_bd_pins util_ad9361_divclk/clk_out]
                     connect_bd_net [get_bd_pins util_ad9361_divclk_reset/interconnect_aresetn] [get_bd_pins axi_cpu_interconnect/M09_ARESETN]
                 }
-                zc706 {                    
+                zc706 {
                     # Add 1 extra AXI master ports to the interconnect
                     set_property -dict [list CONFIG.NUM_MI {10}] [get_bd_cells axi_cpu_interconnect]
                     connect_bd_net -net [get_bd_nets util_ad9361_divclk_clk_out] [get_bd_pins axi_cpu_interconnect/M09_ACLK] [get_bd_pins util_ad9361_divclk/clk_out]
@@ -206,7 +206,7 @@ proc preprocess_bd {project carrier rxtx} {
                 delete_bd_objs [get_bd_nets util_ad9361_dac_upack_fifo_rd_data_5]
                 delete_bd_objs [get_bd_nets util_ad9361_dac_upack_fifo_rd_data_6]
                 delete_bd_objs [get_bd_nets util_ad9361_dac_upack_fifo_rd_data_7]
-            }            
+            }
             # Add 1 extra AXI master ports to the interconnect
             set_property -dict [list CONFIG.NUM_MI {11}] [get_bd_cells axi_cpu_interconnect]
             connect_bd_net -net [get_bd_nets util_ad9361_divclk_clk_out] [get_bd_pins axi_cpu_interconnect/M10_ACLK] [get_bd_pins util_ad9361_divclk/clk_out]
@@ -251,7 +251,7 @@ proc preprocess_bd {project carrier rxtx} {
                 connect_bd_net [get_bd_pins util_adrv9009_rx_cpack/enable_0] [get_bd_pins util_adrv9009_rx_cpack/enable_2]
                 connect_bd_net [get_bd_pins util_adrv9009_rx_cpack/enable_0] [get_bd_pins util_adrv9009_rx_cpack/enable_3]
                 # Connect enables
-                connect_bd_net [get_bd_pins rx_adrv9009_tpl_core/adc_enable_0] [get_bd_pins util_adrv9009_rx_cpack/enable_0]               
+                connect_bd_net [get_bd_pins rx_adrv9009_tpl_core/adc_enable_0] [get_bd_pins util_adrv9009_rx_cpack/enable_0]
             }
             if {$rxtx == "tx" || $rxtx == "rxtx"} {
                 # Remove interpolators
@@ -358,7 +358,7 @@ proc preprocess_bd {project carrier rxtx} {
                     set_property -dict [list CONFIG.NUM_MI {14}] [get_bd_cells axi_cpu_interconnect]
                     connect_bd_net [get_bd_pins axi_cpu_interconnect/M13_ACLK] [get_bd_pins sys_ps8/pl_clk0]
                     connect_bd_net [get_bd_pins axi_cpu_interconnect/M13_ARESETN] [get_bd_pins sys_rstgen/peripheral_aresetn]
-                    
+
                     if {$rxtx == "rx" || $rxtx == "rxtx"} {
                         # connect_bd_net [get_bd_pins axi_cpu_interconnect/M13_ACLK] [get_bd_pins core_clk_d]
                         # connect_bd_net [get_bd_pins core_clk_d_rstgen/interconnect_aresetn] [get_bd_pins axi_cpu_interconnect/M13_ARESETN]
@@ -370,10 +370,10 @@ proc preprocess_bd {project carrier rxtx} {
                     if {$rxtx == "tx"} {
                         # connect_bd_net [get_bd_pins axi_cpu_interconnect/M13_ACLK] [get_bd_pins core_clk_c]
                     }
-                }                
+                }
             }
         }
-        adrv9001 {            
+        adrv9001 {
             if {$rxtx == "rx" || $rxtx == "rxtx"} {
                 # Remove ADC->Pack
                 delete_bd_objs [get_bd_nets axi_adrv9001_adc_1_data_i0]
@@ -389,15 +389,17 @@ proc preprocess_bd {project carrier rxtx} {
                 delete_bd_objs [get_bd_nets util_dac_1_upack_fifo_rd_data_1]
                 delete_bd_objs [get_bd_nets util_dac_1_upack_fifo_rd_data_2]
                 delete_bd_objs [get_bd_nets util_dac_1_upack_fifo_rd_data_3]
-            }
-            switch $carrier {                
-                zcu102 {                    
+            	# Remove valid
+		delete_bd_objs [get_bd_nets axi_adrv9001_dac_1_valid_i0]
+	    }
+            switch $carrier {
+                zcu102 {
                     # Add 1 extra AXI master ports to the interconnect
                     set_property -dict [list CONFIG.NUM_MI {7}] [get_bd_cells axi_cpu_interconnect]
                     # Connect clock and reset
                     connect_bd_net [get_bd_pins axi_cpu_interconnect/M06_ACLK] [get_bd_pins sys_ps8/pl_clk0]
                     connect_bd_net [get_bd_pins axi_cpu_interconnect/M06_ARESETN] [get_bd_pins sys_rstgen/peripheral_aresetn]
-                }                
+                }
             }
         }
         adrv9371x {
@@ -460,15 +462,15 @@ proc preprocess_bd {project carrier rxtx} {
                     set_property -dict [list CONFIG.NUM_MI {17}] [get_bd_cells axi_cpu_interconnect]
                     #connect_bd_net -net [get_bd_nets axi_adrv9009_rx_clkgen] [get_bd_pins axi_cpu_interconnect/M16_ACLK] [get_bd_pins axi_adrv9009_rx_clkgen/clk_0]
                     connect_bd_net [get_bd_pins sys_rstgen/interconnect_aresetn] [get_bd_pins axi_cpu_interconnect/M16_ARESETN]
-                    
+
                     if {$rxtx == "rx" || $rxtx == "rxtx"} {
                         connect_bd_net -net [get_bd_nets axi_ad9371_rx_clkgen] [get_bd_pins axi_cpu_interconnect/M16_ACLK] [get_bd_pins axi_ad9371_rx_clkgen/clk_0]
-                    }                    
+                    }
                     if {$rxtx == "tx"} {
                         # Remove valid combiner
                         delete_bd_objs [get_bd_nets tx_fir_interpolator_valid_out_0] [get_bd_nets tx_fir_interpolator_valid_out_2] [get_bd_nets logic_or_Res] [get_bd_cells logic_or]
                         connect_bd_net -net [get_bd_nets axi_ad9371_tx_clkgen] [get_bd_pins axi_cpu_interconnect/M16_ACLK] [get_bd_pins axi_ad9371_tx_clkgen/clk_0]
-                    }                    
+                    }
                 }
             }
         }


### PR DESCRIPTION
The fifo_rd_en port of the util_dac_1_upack was already driven by axi_adrv9001/dac_1_valid_i0 and it generated an error in the HWA when trying to connect it to the IP Load Tx Data OUT port of the HDL_DUT_IP. 

This fix deletes the net in the preprocessing script and fixes the error.