### PR TITLE
Update FHM calibration attribute naming

### DIFF
--- a/+adi/+ADRV9009/ORx.m
+++ b/+adi/+ADRV9009/ORx.m
@@ -176,7 +176,7 @@ classdef ORx < adi.ADRV9009.Base & adi.common.Rx
             obj.setAttributeLongLong('altvoltage0','frequency',obj.CenterFrequency,true);            
             obj.setAttributeRAW('voltage2','rf_port_select',obj.LOSourceSelect,false);
             obj.setAttributeDouble('voltage2','hardwaregain',obj.Gain,false);
-            obj.setDeviceAttributeRAW('calibrate_frm_en',num2str(obj.EnableFrequencyHoppingModeCalibration));
+            obj.setDeviceAttributeRAW('calibrate_fhm_en',num2str(obj.EnableFrequencyHoppingModeCalibration));
             
             % Bring stuff back up as desired
             obj.setAttributeBool('voltage2','powerdown',obj.PowerdownChannel0,false);

--- a/+adi/+ADRV9009/Rx.m
+++ b/+adi/+ADRV9009/Rx.m
@@ -216,7 +216,7 @@ classdef Rx < adi.ADRV9009.Base & adi.common.Rx
             % Do one shot cals
             obj.setDeviceAttributeRAW('calibrate_rx_qec_en',num2str(obj.EnableQuadratureCalibration));
             obj.setDeviceAttributeRAW('calibrate_rx_phase_correction_en',num2str(obj.EnablePhaseCorrection));
-            obj.setDeviceAttributeRAW('calibrate_frm_en',num2str(obj.EnableFrequencyHoppingModeCalibration));
+            obj.setDeviceAttributeRAW('calibrate_fhm_en',num2str(obj.EnableFrequencyHoppingModeCalibration));
             obj.setDeviceAttributeRAW('calibrate',num2str(true));
             
             % Bring stuff back up as desired

--- a/+adi/+ADRV9009/Tx.m
+++ b/+adi/+ADRV9009/Tx.m
@@ -199,7 +199,7 @@ classdef Tx < adi.ADRV9009.Base & adi.common.Tx
             obj.setDeviceAttributeRAW('calibrate_tx_qec_en',num2str(obj.EnableQuadratureCalibration));
             obj.setDeviceAttributeRAW('calibrate_tx_lol_en',num2str(obj.EnableLOLeakageCorrection));
             obj.setDeviceAttributeRAW('calibrate_tx_lol_ext_en',num2str(obj.EnableLOLeakageCorrectionExternal));
-            obj.setDeviceAttributeRAW('calibrate_frm_en',num2str(obj.EnableFrequencyHoppingModeCalibration));
+            obj.setDeviceAttributeRAW('calibrate_fhm_en',num2str(obj.EnableFrequencyHoppingModeCalibration));
             obj.setDeviceAttributeRAW('calibrate',num2str(true));
 
             % Bring stuff back up as desired

--- a/+adi/+ADRV9009ZU11EG/Rx.m
+++ b/+adi/+ADRV9009ZU11EG/Rx.m
@@ -280,14 +280,14 @@ classdef Rx < adi.ADRV9009ZU11EG.Base & adi.ADRV9009.Rx
             obj.setDeviceAttributeRAW('calibrate_rx_qec_en',num2str(obj.EnableQuadratureCalibration));
             obj.setDeviceAttributeRAW('calibrate_rx_phase_correction_en',num2str(obj.EnablePhaseCorrection));
             if strcmpi(class(obj),'adi.ADRV9009ZU11EG.Rx')
-                obj.setDeviceAttributeRAW('calibrate_frm_en',num2str(obj.EnableFrequencyHoppingModeCalibration));
+                obj.setDeviceAttributeRAW('calibrate_fhm_en',num2str(obj.EnableFrequencyHoppingModeCalibration));
             end
             obj.setDeviceAttributeRAW('calibrate',num2str(true));
 
             obj.setDeviceAttributeRAW('calibrate_rx_qec_en',num2str(obj.EnableQuadratureCalibrationChipB),obj.iioDevChipB);
             obj.setDeviceAttributeRAW('calibrate_rx_phase_correction_en',num2str(obj.EnablePhaseCorrectionChipB),obj.iioDevChipB);
             if strcmpi(class(obj),'adi.ADRV9009ZU11EG.Rx')
-                obj.setDeviceAttributeRAW('calibrate_frm_en',num2str(obj.EnableFrequencyHoppingModeCalibrationChipB),obj.iioDevChipB);
+                obj.setDeviceAttributeRAW('calibrate_fhm_en',num2str(obj.EnableFrequencyHoppingModeCalibrationChipB),obj.iioDevChipB);
             end
             obj.setDeviceAttributeRAW('calibrate',num2str(true),obj.iioDevChipB);
 

--- a/+adi/+ADRV9009ZU11EG/Tx.m
+++ b/+adi/+ADRV9009ZU11EG/Tx.m
@@ -250,7 +250,7 @@ classdef Tx < adi.ADRV9009ZU11EG.Base & adi.ADRV9009.Tx
             obj.setDeviceAttributeRAW('calibrate_tx_lol_en',num2str(obj.EnableLOLeakageCorrection));
             obj.setDeviceAttributeRAW('calibrate_tx_lol_ext_en',num2str(obj.EnableLOLeakageCorrectionExternal));
             if strcmpi(class(obj),'adi.ADRV9009ZU11EG.Tx')
-                obj.setDeviceAttributeRAW('calibrate_frm_en',num2str(obj.EnableFrequencyHoppingModeCalibration));
+                obj.setDeviceAttributeRAW('calibrate_fhm_en',num2str(obj.EnableFrequencyHoppingModeCalibration));
             end
             obj.setDeviceAttributeRAW('calibrate',num2str(true));
             
@@ -258,7 +258,7 @@ classdef Tx < adi.ADRV9009ZU11EG.Base & adi.ADRV9009.Tx
             obj.setDeviceAttributeRAW('calibrate_tx_lol_en',num2str(obj.EnableLOLeakageCorrectionChipB),obj.iioDevChipB);
             obj.setDeviceAttributeRAW('calibrate_tx_lol_ext_en',num2str(obj.EnableLOLeakageCorrectionExternalChipB),obj.iioDevChipB);
             if strcmpi(class(obj),'adi.ADRV9009ZU11EG.Tx')
-                obj.setDeviceAttributeRAW('calibrate_frm_en',num2str(obj.EnableFrequencyHoppingModeCalibrationChipB),obj.iioDevChipB);
+                obj.setDeviceAttributeRAW('calibrate_fhm_en',num2str(obj.EnableFrequencyHoppingModeCalibrationChipB),obj.iioDevChipB);
             end
             obj.setDeviceAttributeRAW('calibrate',num2str(true),obj.iioDevChipB);
             


### PR DESCRIPTION
2021-R1 updates FHM attribute naming for ADRV9009

Signed-off-by: Travis F. Collins <travis.collins@analog.com>