### PR TITLE
[FIX] AGC class missing RxTx base inheritance

### DIFF
--- a/+adi/+AD9361/TuneAGC.m
+++ b/+adi/+AD9361/TuneAGC.m
@@ -1,4 +1,6 @@
-classdef TuneAGC < adi.common.DebugAttribute & adi.common.RegisterReadWrite        
+classdef TuneAGC < adi.common.DebugAttribute & ...
+        adi.common.RxTx & ...
+        adi.common.RegisterReadWrite
     properties (Nontunable, Hidden)
         CustomAGC = 0;
         


### PR DESCRIPTION
Signed-off-by: Travis F. Collins <travis.collins@analog.com>