### PR TITLE
Do not set python

### DIFF
--- a/JenkinsfileHW
+++ b/JenkinsfileHW
@@ -72,7 +72,6 @@ lock(label: 'adgt_test_harness_boards') {
     harness.set_matlab_commands(["ad=adi.utils.libad9361",
                     "ad.download_libad9361()",
                     "addpath(genpath('test'))",
-                    "pyenv('Version','/usr/bin/python3')",
                     "runHWTests(getenv('board'))"])
     harness.add_stage(harness.stage_library("MATLABTests"),'continueWhenFail')
   


### PR DESCRIPTION
Python is set for using telemetry inside MATLAB which is not done for all toolboxes except LTE tests pipeline. The docker image for the test pipelines is still using python3.8 but it is no longer compatible. Might as well remove it from the Jenkinsfile.