### PR TITLE
Add labgrid-driven hardware CI (adi-lg-matlab)

### DIFF
--- a/.github/workflows/depends.yml
+++ b/.github/workflows/depends.yml
@@ -40,13 +40,13 @@ jobs:
 
   build_windows:
     name: Build libad9361-iio for Windows
-    runs-on: windows-2019
+    runs-on: windows-2022
 
     steps:
       - name: Setup MSBuild
         uses: microsoft/setup-msbuild@v2
         with:
-          vs-version: '[16.0,17.0)'  # VS 2019
+          vs-version: '[17.0,18.0)'  # VS 2022 (windows-2019 image was retired)
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/hw-matlab.yml
+++ b/.github/workflows/hw-matlab.yml
@@ -123,7 +123,10 @@ jobs:
 
   publish:
     needs: hw
-    if: always()
+    # Run only when the hw matrix actually ran (i.e. the hw-test path was
+    # taken). When hw is skipped, there is nothing to publish — skip too,
+    # so this job never sits pending on a PR that has no HW runner.
+    if: ${{ always() && needs.hw.result != 'skipped' }}
     runs-on: [self-hosted, hw-coordinator]
     # The test-result action posts a check run and a PR comment.
     permissions:

--- a/.github/workflows/hw-matlab.yml
+++ b/.github/workflows/hw-matlab.yml
@@ -1,0 +1,131 @@
+name: Hardware Tests (labgrid)
+
+# Bespoke MATLAB hardware-CI workflow. labgrid (adi-labgrid-plugins) boots
+# the board for a coordinator place, hands MATLAB the booted board's libIIO
+# URI via the IIO_URI env var, and runs runHWTests against it.
+#
+# Two job stages:
+#   discover  — on a coordinator-adjacent runner, intersect live coordinator
+#               places with test/hw_ci/board_map.yaml -> matrix of places.
+#   hw        — one shard per place, pinned to its hw-<place> self-hosted
+#               runner (which must have MATLAB + libiio installed), boots the
+#               board and runs MATLAB.
+#
+# Requires a coordinator reachable at vars.ADI_LG_COORDINATOR and self-hosted
+# runners labeled [self-hosted, hw-coordinator] and [self-hosted, hw-<place>]
+# per the adi-labgrid-plugins HW-CI runner contract.
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 8 * * *"
+  pull_request:
+    types: [labeled, opened, synchronize, reopened]
+
+# A pinned reference to adi-labgrid-plugins. Bump alongside the coordinator.
+env:
+  ADI_LG_PLUGINS_REF: "v2"
+  VENV_DIR: "${{ github.workspace }}/.hw-ci-venv"
+  MATLAB_BIN: "/opt/MATLAB/R2025b/bin/matlab"
+
+jobs:
+  discover:
+    # Only on PRs that opt in with the `hw-test` label; always on dispatch/cron.
+    if: >-
+      github.event_name != 'pull_request' ||
+      contains(github.event.pull_request.labels.*.name, 'hw-test')
+    runs-on: [self-hosted, hw-coordinator]
+    outputs:
+      matrix: ${{ steps.discover.outputs.matrix }}
+      count: ${{ steps.discover.outputs.count }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup venv (adi-labgrid-plugins)
+        uses: tfcollins/labgrid-plugins/.github/actions/setup-uv-venv@v2
+        with:
+          venv_dir: ${{ env.VENV_DIR }}
+          install_cmd: >-
+            uv pip install --python "$VENV_DIR/bin/python"
+            "adi-labgrid-plugins @ git+https://github.com/tfcollins/labgrid-plugins.git@${{ env.ADI_LG_PLUGINS_REF }}"
+
+      - name: Discover places
+        id: discover
+        env:
+          LG_COORDINATOR: ${{ vars.ADI_LG_COORDINATOR }}
+        run: |
+          "$VENV_DIR/bin/adi-lg-matlab" discover \
+            --coord "$LG_COORDINATOR" \
+            --board-map test/hw_ci/board_map.yaml \
+            --github-output
+
+  hw:
+    needs: discover
+    if: ${{ needs.discover.outputs.count != '0' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJSON(needs.discover.outputs.matrix).include }}
+    runs-on: [self-hosted, "hw-${{ matrix.place }}"]
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup venv (adi-labgrid-plugins)
+        uses: tfcollins/labgrid-plugins/.github/actions/setup-uv-venv@v2
+        with:
+          venv_dir: ${{ env.VENV_DIR }}
+          install_cmd: >-
+            uv pip install --python "$VENV_DIR/bin/python"
+            "adi-labgrid-plugins @ git+https://github.com/tfcollins/labgrid-plugins.git@${{ env.ADI_LG_PLUGINS_REF }}"
+
+      - name: Acquire place
+        uses: tfcollins/labgrid-plugins/.github/actions/acquire-place@v2
+        with:
+          coordinator: ${{ vars.ADI_LG_COORDINATOR }}
+          place: ${{ matrix.place }}
+          labgrid_client: ${{ env.VENV_DIR }}/bin/labgrid-client
+
+      - name: Boot board + run MATLAB HW tests
+        env:
+          LG_COORDINATOR: ${{ vars.ADI_LG_COORDINATOR }}
+        run: |
+          # Place is already acquired by the composite action above, so do
+          # NOT pass --acquire here (avoids double-acquire).
+          "$VENV_DIR/bin/adi-lg-matlab" run \
+            --coord "$LG_COORDINATOR" \
+            --place "${{ matrix.place }}" \
+            --board-map test/hw_ci/board_map.yaml \
+            --repo-dir "$GITHUB_WORKSPACE" \
+            --matlab "$MATLAB_BIN" \
+            --junit "junit-${{ matrix.place }}.xml"
+
+      - name: Release place
+        if: always()
+        run: |
+          "$VENV_DIR/bin/labgrid-client" -x "${{ vars.ADI_LG_COORDINATOR }}" \
+            -p "${{ matrix.place }}" release || true
+
+      - name: Upload JUnit + MATLAB logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: hw-results-${{ matrix.place }}
+          path: |
+            junit-${{ matrix.place }}.xml
+            ${{ matrix.matlab_board }}_HWTestResults.xml
+            failures.txt
+          if-no-files-found: ignore
+
+  publish:
+    needs: hw
+    if: always()
+    runs-on: [self-hosted, hw-coordinator]
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: hw-results
+      - name: Publish test summary
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        with:
+          junit_files: "hw-results/**/junit-*.xml"

--- a/.github/workflows/hw-matlab.yml
+++ b/.github/workflows/hw-matlab.yml
@@ -28,6 +28,10 @@ env:
   VENV_DIR: "${{ github.workspace }}/.hw-ci-venv"
   MATLAB_BIN: "/opt/MATLAB/R2025b/bin/matlab"
 
+# Minimal default token permissions; the publish job widens its own below.
+permissions:
+  contents: read
+
 jobs:
   discover:
     # Only on PRs that opt in with the `hw-test` label; always on dispatch/cron.
@@ -121,6 +125,11 @@ jobs:
     needs: hw
     if: always()
     runs-on: [self-hosted, hw-coordinator]
+    # The test-result action posts a check run and a PR comment.
+    permissions:
+      contents: read
+      checks: write
+      pull-requests: write
     steps:
       - uses: actions/download-artifact@v4
         with:

--- a/README.md
+++ b/README.md
@@ -36,3 +36,36 @@ rgetz@pinky:~/TransceiverToolbox$ make -C CI/scripts/ build
 
 Then simply add the `hdl` folder to your MATLAB path `addpath(genpath('hdl'))`
 
+## Hardware Testing with labgrid
+
+The MATLAB hardware tests (`runHWTests`) connect to a board over a libIIO URI
+and honor the `IIO_URI` environment variable. They assume the board is already
+powered, booted, and reachable.
+
+[adi-labgrid-plugins](https://github.com/analogdevicesinc/adi-labgrid-plugins)
+can provision that board automatically — power it, boot the FPGA/SoC, and hand
+MATLAB the booted board's URI — both locally and in GitHub Actions, via the
+`adi-lg-matlab` launcher.
+
+The mapping from a labgrid place (tagged with `carrier` / `daughter-board`) to
+the MATLAB board reference name that `runHWTests` expects lives in
+[`test/hw_ci/board_map.yaml`](test/hw_ci/board_map.yaml).
+
+Run locally against a coordinator place:
+
+```bash
+pip install "adi-labgrid-plugins @ git+https://github.com/tfcollins/labgrid-plugins.git@v2"
+
+adi-lg-matlab run \
+    --coord $LG_COORDINATOR --place mini2 \
+    --board-map test/hw_ci/board_map.yaml \
+    --repo-dir . --matlab /opt/MATLAB/R2025b/bin/matlab \
+    --junit junit-mini2.xml --acquire
+```
+
+This boots the board, sets `IIO_URI`, runs `runHWTests`, copies the JUnit
+results, and releases the place. The GitHub Actions equivalent is
+[`.github/workflows/hw-matlab.yml`](.github/workflows/hw-matlab.yml). See the
+[MATLAB Hardware CI guide](https://adi-labgrid-plugins.readthedocs.io/en/latest/user-guide/matlab-hw-ci.html)
+for details.
+

--- a/test/hw_ci/board_map.yaml
+++ b/test/hw_ci/board_map.yaml
@@ -1,0 +1,57 @@
+# TransceiverToolbox board map for labgrid HW-CI (adi-lg-matlab).
+#
+# Maps a labgrid coordinator place's tags -> the MATLAB board reference
+# name that `runHWTests(board)` understands (the values in the `switch`
+# in test/runHWTests.m). adi-lg-matlab uses this to translate a booted
+# place into the right `board` argument.
+#
+# Matching rules (see adi_lg_plugins.matlab_ci.board_map):
+#   * `daughter-board` is required and matched against the place's
+#     `daughter-board` tag.
+#   * `carrier` / `hdl-config`, when present, must also match the place's
+#     tags; the MOST specific matching row wins. A row without `carrier`
+#     is a carrier-agnostic fallback.
+#
+# The `daughter-board` / `carrier` values below must match the tags the
+# lab admin set on each place, e.g.:
+#   labgrid-client -p mini2 set-tags carrier=zcu102 daughter-board=adrv9002 \
+#       boot-strategy=BootFPGASoC
+#
+# NOTE: this duplicates knowledge in test/runHWTests.m's switch — keep the
+# two in sync when adding boards.
+
+boards:
+  # --- AD9361 (FMComms2/3) ---
+  - {carrier: zcu102, daughter-board: ad9361, matlab_board: zynqmp-zcu102-rev10-ad9361-fmcomms2-3}
+  - {carrier: zc706,  daughter-board: ad9361, matlab_board: zynq-zc706-adv7511-ad9361-fmcomms2-3}
+  - {carrier: zc702,  daughter-board: ad9361, matlab_board: zynq-zc702-adv7511-ad9361-fmcomms2-3}
+  - {carrier: zed,    daughter-board: ad9361, matlab_board: zynq-zed-adv7511-ad9361-fmcomms2-3}
+
+  # --- AD9364 (FMComms4) ---
+  - {carrier: zcu102, daughter-board: ad9364, matlab_board: zynqmp-zcu102-rev10-ad9364-fmcomms4}
+  - {carrier: zc706,  daughter-board: ad9364, matlab_board: zynq-zc706-adv7511-ad9364-fmcomms4}
+  - {carrier: zed,    daughter-board: ad9364, matlab_board: zynq-zed-adv7511-ad9364-fmcomms4}
+
+  # --- FMComms5 (dual AD9361) ---
+  - {carrier: zcu102, daughter-board: fmcomms5, matlab_board: zynqmp-zcu102-rev10-ad9361-fmcomms5}
+  - {carrier: zc706,  daughter-board: fmcomms5, matlab_board: zynq-zc706-adv7511-ad9361-fmcomms5}
+
+  # --- AD9371 / ADRV9371 ---
+  - {carrier: zcu102, daughter-board: adrv9371, matlab_board: zynqmp-zcu102-rev10-adrv9371}
+  - {carrier: zc706,  daughter-board: adrv9371, matlab_board: zynq-zc706-adv7511-adrv9371}
+
+  # --- ADRV9002 (CMOS default; hdl-config selects LVDS vs CMOS) ---
+  - {carrier: zcu102, daughter-board: adrv9002, matlab_board: zynqmp-zcu102-rev10-adrv9002-vcmos}
+  - {carrier: zcu102, daughter-board: adrv9002, hdl-config: lvds, matlab_board: zynqmp-zcu102-rev10-adrv9002-vlvds}
+  - {carrier: zcu102, daughter-board: adrv9002, hdl-config: cmos, matlab_board: zynqmp-zcu102-rev10-adrv9002-vcmos}
+  - {carrier: zed,    daughter-board: adrv9002, matlab_board: zynq-zed-adv7511-adrv9002-vcmos}
+
+  # --- ADRV9009 ---
+  - {carrier: zcu102, daughter-board: adrv9009, matlab_board: zynqmp-zcu102-rev10-adrv9009}
+  - {carrier: zc706,  daughter-board: adrv9009, matlab_board: zynq-zc706-adv7511-adrv9009}
+
+  # --- FMComms8 (dual ADRV9009) ---
+  - {carrier: zcu102, daughter-board: fmcomms8, matlab_board: zynqmp-zcu102-rev10-adrv9009-fmcomms8}
+
+  # --- Pluto (self-contained) ---
+  - {daughter-board: pluto, matlab_board: pluto}


### PR DESCRIPTION
## What

Lets labgrid ([adi-labgrid-plugins](https://github.com/analogdevicesinc/adi-labgrid-plugins)) provision a board — power it, boot the FPGA/SoC, and hand MATLAB the booted board's libIIO URI — so the existing `runHWTests` run against it, both locally and in GitHub Actions.

`runHWTests` already honours `IIO_URI`, so **no MATLAB source change** is needed: the `adi-lg-matlab` launcher boots the board, sets `IIO_URI`/`board`, runs the tests, and copies the JUnit output.

## Contents

- **`test/hw_ci/board_map.yaml`** — maps labgrid place tags (`carrier` / `daughter-board` / `hdl-config`) to the MATLAB board reference names in `runHWTests.m`'s `switch`. Keep in sync with that switch.
- **`.github/workflows/hw-matlab.yml`** — bespoke workflow: a `discover` job on a coordinator-adjacent runner builds the matrix; per-place shards on `hw-<place>` self-hosted runners (MATLAB + libiio) acquire the place, run `adi-lg-matlab`, release on `always()`, and upload JUnit.
- **README** — local + CI usage.

## Prerequisites / notes

- Depends on the `adi-lg-matlab` launcher in adi-labgrid-plugins (tfcollins/labgrid-plugins#31). The workflow pins `@v2`, so that change must land on the `v2` ref first.
- The `daughter-board`/`carrier` values in `board_map.yaml` must match the tags the lab admin sets on each coordinator place — adjust to your lab's convention.
- `hw-<place>` runners must have MATLAB (R2025b on nemo) + a batch license + libiio. The workflow's `MATLAB_BIN` defaults to `/opt/MATLAB/R2025b/bin/matlab`.