### PR TITLE
hw-matlab.yml: pass --skip-boot to adi-lg-matlab run

### DIFF
--- a/.github/workflows/hw-matlab.yml
+++ b/.github/workflows/hw-matlab.yml
@@ -96,12 +96,21 @@ jobs:
         run: |
           # Place is already acquired by the composite action above, so do
           # NOT pass --acquire here (avoids double-acquire).
+          # --skip-boot: the lab's coordinator places are tagged with
+          # boot-strategy=BootZynq7000JTAGRecovery, whose template does
+          # not yet expose the consumer-supplied kernel/uboot/initramfs/
+          # bitstream paths needed for a real transition. Acquire the
+          # place and resolve its NetworkService URI; let the toolbox's
+          # CheckDevice handle reachability gracefully via assumeFail
+          # until the lab supplies those inputs (see adi-labgrid-plugins
+          # #33 for the --skip-boot mechanic).
           "$VENV_DIR/bin/adi-lg-matlab" run \
             --coord "$LG_COORDINATOR" \
             --place "${{ matrix.place }}" \
             --board-map test/hw_ci/board_map.yaml \
             --repo-dir "$GITHUB_WORKSPACE" \
             --matlab "$MATLAB_BIN" \
+            --skip-boot \
             --junit "junit-${{ matrix.place }}.xml"
 
       - name: Release place


### PR DESCRIPTION
Make the HW matrix shards actually reach MATLAB. Today they fail at strategy instantiation because the lab's coordinator places are tagged \`boot-strategy=BootZynq7000JTAGRecovery\`, whose env-yaml template doesn't yet expose the consumer-supplied kernel/uboot/initramfs/bitstream paths needed for a real \`strategy.transition()\`.

\`--skip-boot\` (added in tfcollins/labgrid-plugins#33, merged) makes the launcher acquire the place and resolve the \`NetworkService\` URI without trying to transition the strategy. The toolbox's \`test/HardwareTests.m\` already honours \`IIO_URI\` and \`CheckDevice\` gracefully \`assumeFail\`s when libIIO can't reach the address — so the full pipeline (acquire → resolve URI → MATLAB launch → JUnit → release) is exercised, and when the lab eventually supplies the recovery inputs the boards will report real test outcomes.

Drop the flag once the lab template carries the recovery inputs (or the lab retags places with a boot-strategy that has plug-and-play inputs, like \`BootFPGASoC\` for SD-Mux setups).