### PR TITLE
hw-matlab.yml: make MATLAB_BIN a repo variable (vars.MATLAB_BIN)

### DIFF
--- a/.github/workflows/hw-matlab.yml
+++ b/.github/workflows/hw-matlab.yml
@@ -26,7 +26,9 @@ on:
 env:
   ADI_LG_PLUGINS_REF: "v2"
   VENV_DIR: "${{ github.workspace }}/.hw-ci-venv"
-  MATLAB_BIN: "/opt/MATLAB/R2025b/bin/matlab"
+  # MATLAB binary path on the hw-<place> runner. Override per-repo with
+  # vars.MATLAB_BIN — lab MATLAB installs vary (/opt vs /mnt vs /usr/local).
+  MATLAB_BIN: "${{ vars.MATLAB_BIN || '/opt/MATLAB/R2025b/bin/matlab' }}"
 
 # Minimal default token permissions; the publish job widens its own below.
 permissions:


### PR DESCRIPTION
The previous workflow hard-coded `MATLAB_BIN: /opt/MATLAB/R2025b/bin/matlab`. Lab hosts ship MATLAB at different paths (/opt, /mnt, /usr/local depending on installer). Read from `vars.MATLAB_BIN` and fall back to `/opt/MATLAB/R2025b/bin/matlab` if unset, so each repo/lab can override without editing the workflow.

Surfaced when the first self-hosted HW runner failed at `adi-lg-matlab run` with `FileNotFoundError: /opt/MATLAB/R2025b/bin/matlab` — the runner host has MATLAB at `/mnt/onetb/MATLAB/R2025b/bin/matlab`. With this PR + `vars.MATLAB_BIN` set, the next HW CI run resolves the actual path.