### PR TITLE
hw-matlab.yml: checkout submodules + treat MATLAB exit 3 as success

### DIFF
--- a/.github/workflows/hw-matlab.yml
+++ b/.github/workflows/hw-matlab.yml
@@ -76,6 +76,11 @@ jobs:
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
+        with:
+          # +adi/+common is a git submodule (ToolboxCommon shared across ADI
+          # MATLAB toolboxes). Without it MATLAB can't resolve adi.common.RxTx
+          # superclass and every test fails to instantiate.
+          submodules: recursive
 
       - name: Setup venv (adi-labgrid-plugins)
         uses: tfcollins/labgrid-plugins/.github/actions/setup-uv-venv@v2
@@ -106,6 +111,13 @@ jobs:
           # CheckDevice handle reachability gracefully via assumeFail
           # until the lab supplies those inputs (see adi-labgrid-plugins
           # #33 for the --skip-boot mechanic).
+          # runHWTests exit codes (see test/runHWTests.m):
+          #   0 = all passed, 2 = one or more failed, 3 = one or more Incomplete.
+          # When --skip-boot is used (board not booted), CheckDevice's
+          # assumeFail filters every test -> exit 3. That's not a CI failure;
+          # the JUnit reflects the skipped status and `publish` aggregates it.
+          # Treat exit 3 as success here; let exit 2 (real failure) propagate.
+          set +e
           "$VENV_DIR/bin/adi-lg-matlab" run \
             --coord "$LG_COORDINATOR" \
             --place "${{ matrix.place }}" \
@@ -114,6 +126,12 @@ jobs:
             --matlab "$MATLAB_BIN" \
             --skip-boot \
             --junit "junit-${{ matrix.place }}.xml"
+          rc=$?
+          if [ "$rc" = "3" ]; then
+            echo "::notice::All tests Incomplete (skipped via CheckDevice; expected with --skip-boot)"
+            exit 0
+          fi
+          exit "$rc"
 
       - name: Release place
         if: always()


### PR DESCRIPTION
Two real fixes surfaced by the first end-to-end CI run on a self-hosted runner:

1. `actions/checkout@v4` now uses `submodules: recursive`. `+adi/+common` is a git submodule (ToolboxCommon, shared across ADI MATLAB toolboxes); without it MATLAB can't resolve the `adi.common.RxTx` superclass and every test class fails to instantiate.

2. `runHWTests` exits **3** when one or more tests are Incomplete (the `assumeFail` graceful-skip from `HardwareTests.CheckDevice` when libIIO can't reach the board). With `--skip-boot` — today's lab reality — *all* tests skip and the launcher propagates exit 3. That isn't a CI failure: the JUnit reflects `skipped` status and the `publish` job aggregates it. Treat exit 3 as success at the step level; let exit 2 (real test failures) and anything else still fail.

Together these unblock the HW matrix from cleanly reporting JUnit-aggregated results to the publish job, instead of being marked failed by an exit code that is semantically a clean skip.