### PR TITLE
docs: fix Sphinx linkcheck failures

### DIFF
--- a/CI/doc/gen_pages/_templates/sysobj.html
+++ b/CI/doc/gen_pages/_templates/sysobj.html
@@ -39,9 +39,11 @@ For more information on changing property values, see <a href="https://www.mathw
 
 
 {% for prop in obj.props %}
+{% if prop.prop_description | trim %}
 :::{collapsible} {{ prop.prop_name }}
 {{ prop.prop_description }}
 :::
+{% endif %}
 {% endfor -%}
 
 

--- a/CI/doc/gen_pages/gen_hdl_refdesigns.py
+++ b/CI/doc/gen_pages/gen_hdl_refdesigns.py
@@ -50,7 +50,11 @@ def update_hdl_refdesigns():
         else:
             objs[obj]["rd_image"] = "jesd"
 
-        objs[obj]["hdl_rd_doc"] = f"https://analogdevicesinc.github.io/hdl/projects/{objs[obj]['name']}/index.html"
+        hdl_doc_project = {
+            "adrv9002": "adrv9001",
+            "adrv9371": "adrv9371x",
+        }.get(objs[obj]["name"], objs[obj]["name"])
+        objs[obj]["hdl_rd_doc"] = f"https://analogdevicesinc.github.io/hdl/projects/{hdl_doc_project}/index.html"
 
 
         output = template.render(obj=objs[obj])

--- a/CI/doc/source/conf.py
+++ b/CI/doc/source/conf.py
@@ -111,3 +111,8 @@ html_theme_options = {
     "light_logo": os.path.join("logos", "logo_black_cropped.png"),
     "dark_logo": os.path.join("logos", "logo_white_cropped.png"),
 }
+
+# MathWorks blocks automated link checkers with HTTP 403 even though these
+# documentation pages are valid in a browser. Keep the user-facing links but
+# exclude them from Sphinx linkcheck so real stale links remain visible.
+linkcheck_ignore = [r"https://www\.mathworks\.com/.*"]

--- a/CI/doc/source/dev_hdl_workflow.md
+++ b/CI/doc/source/dev_hdl_workflow.md
@@ -19,7 +19,7 @@ make -C CI/scripts build
 ```
 After the above command completes the HDL source will be in place with necessary changes.
 
-The changes primarily required of the HDL source are interceptions of the build functions (procs) to skip synthesis when building a project. This is done by inserting environmental variable checks into the [adi_project_xilinx.tcl](https://github.com/analogdevicesinc/TransceiverToolbox/blob/master/CI/scripts/adi_project_xilinx.tcl#L138) script. At build time these environmental variables are set and will prevent synthesis. This way an HDL project can be built, then handed off to HDL-Coder for IP insertion and eventual synthesis.
+The changes primarily required of the HDL source are interceptions of the build functions (procs) to skip synthesis when building a project. This is done by inserting environmental variable checks into the [adi_project_xilinx.tcl](https://github.com/analogdevicesinc/TransceiverToolbox/blob/master/CI/scripts/adi_project_xilinx.tcl) script. At build time these environmental variables are set and will prevent synthesis. This way an HDL project can be built, then handed off to HDL-Coder for IP insertion and eventual synthesis.
 
 HDL-Coder is limited to only interact with Vivado or Quartus. Therefore, it cannot leverage the makefiles as traditionally used to build HDL projects in the HDL repository. HDL-Coder and the authored scripts in the toolbox use the [TCL flow](https://wiki.analog.com/resources/fpga/docs/build#xilinx_auto_tcl_build) normally recommended for just Windows users. This is used on all platforms (Windows and Linux) to support HDL code-generation and integration with ADI toolboxes.
 

--- a/CI/doc/source/streaming.md
+++ b/CI/doc/source/streaming.md
@@ -12,7 +12,7 @@ Since libIIO is cross-platform it can be used from Windows, Linux, or macOS base
 ## Connecting and Configuration
 
 <!-- vale Google.Quotes = NO -->
-Connecting to hardware is done by setting the **uri** property of the system object interface. The **uri** for libIIO always has the convention "*< backend >:< address >*", where *backend* can be ip,usb, or serial. *address* will be specific to the backend. This is documented in the [libIIO API](https://analogdevicesinc.github.io/libiio/master/libiio/group__Context.html#gafdcee40508700fa395370b6c636e16fe).
+Connecting to hardware is done by setting the **uri** property of the system object interface. The **uri** for libIIO always has the convention "*< backend >:< address >*", where *backend* can be ip,usb, or serial. *address* will be specific to the backend. This is documented in the [libIIO API](https://analogdevicesinc.github.io/libiio/main/libiio/group__Context.html).
 <!-- vale Google.Quotes = YES -->
 
 Below is a basic example of setting up an AD9361 receiver using an Ethernet/IP backend where the address of the target system is 192.168.2.1:
@@ -110,7 +110,7 @@ tx.step(tx_data); % Step method
 
 However, once the step or operator method is called the object becomes locked and future passed data vectors must be the same length. As with the receive classes, the size of the passed data must be [SomeFixedSize x EnabledChannels]. **EnabledChannels** has the same definition as the receive side, except applied to DACs.
 
-Unlike the receiver, transmit objects have the ability to utilize [cyclic buffers](https://analogdevicesinc.github.io/libiio/group__Buffer.html#ga6caadf077c112ae55a64276aa24ef832) which will continuously transmit a provided vector without gaps forever. To utilize cyclic buffers set the **EnableCyclicBuffers** property then pass the operator data as follows:
+Unlike the receiver, transmit objects have the ability to utilize [cyclic buffers](https://analogdevicesinc.github.io/libiio/main/libiio/group__Buffer.html) which will continuously transmit a provided vector without gaps forever. To utilize cyclic buffers set the **EnableCyclicBuffers** property then pass the operator data as follows:
 
 ```{code} matlab
 tx = adi.ADRV9009.Tx;


### PR DESCRIPTION
## Summary
- skip empty generated System object property blocks so Sphinx builds with warnings as errors
- update stale libiio and HDL reference-design documentation links
- ignore MathWorks URLs in Sphinx linkcheck because they return HTTP 403 to automated checkers while remaining browser-valid

## Verification
- make -C CI/doc gen_autodocs
- make -C CI/doc html SPHINXOPTS='-W --keep-going'
- make -C CI/doc linkcheck SPHINXOPTS='--keep-going'
- git diff --check